### PR TITLE
fmt existingvolume broker

### DIFF
--- a/existingvolumebroker.go
+++ b/existingvolumebroker.go
@@ -12,14 +12,14 @@ import (
 	"regexp"
 	"sync"
 
+	"code.cloudfoundry.org/brokerapi/v13/domain"
+	"code.cloudfoundry.org/brokerapi/v13/domain/apiresponses"
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/goshims/osshim"
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/service-broker-store/brokerstore"
 	vmo "code.cloudfoundry.org/volume-mount-options"
 	vmou "code.cloudfoundry.org/volume-mount-options/utils"
-	"code.cloudfoundry.org/brokerapi/v13/domain"
-	"code.cloudfoundry.org/brokerapi/v13/domain/apiresponses"
 )
 
 const (

--- a/existingvolumebroker_test.go
+++ b/existingvolumebroker_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 
+	"code.cloudfoundry.org/brokerapi/v13/domain"
+	"code.cloudfoundry.org/brokerapi/v13/domain/apiresponses"
 	"code.cloudfoundry.org/existingvolumebroker"
 	"code.cloudfoundry.org/existingvolumebroker/fakes"
 	"code.cloudfoundry.org/goshims/osshim/os_fake"
@@ -19,8 +21,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"code.cloudfoundry.org/brokerapi/v13/domain"
-	"code.cloudfoundry.org/brokerapi/v13/domain/apiresponses"
 )
 
 //counterfeiter:generate -o ./fakes/fake_user_opts_validation.go code.cloudfoundry.org/volume-mount-options.UserOptsValidation

--- a/fakes/fake_services.go
+++ b/fakes/fake_services.go
@@ -4,8 +4,8 @@ package fakes
 import (
 	"sync"
 
-	"code.cloudfoundry.org/existingvolumebroker"
 	"code.cloudfoundry.org/brokerapi/v13/domain"
+	"code.cloudfoundry.org/existingvolumebroker"
 )
 
 type FakeServices struct {


### PR DESCRIPTION
Test results

```
~/workspace/existingvolumebroker |brokerapi-fmt ✔| 
$ ./scripts/create-docker-container.bash 
Using default tag: latest
latest: Pulling from cloudfoundry/tas-runtime-build
Digest: sha256:509a99889f3c5d71e7c32ca60206a5a8be20ae4d2f8c168e7b585b5e96bccf64
Status: Image is up to date for cloudfoundry/tas-runtime-build:latest
docker.io/cloudfoundry/tas-runtime-build:latest
Error response from daemon: No such container: existingvolumebroker-docker-container
root@6d58782ec829:/# ./repo/scripts/docker/test.bash
Verifying: verify_go repo/.
go version go1.26.1 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Skipping this verification, since it's not a bosh release
Verifying: verify_gofmt repo/.
Verifying: verify_govet repo/.
Verifying: verify_staticcheck repo/.
[1774450255] Broker Suite - 4104/4104 specs - 7 procs •••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 12.189681579s 
[1774450255] Utils Suite - 3/3 specs - 7 procs ••• SUCCESS! 88.375621ms 

Ginkgo ran 2 suites in 1m9.008825058s
Test Suite Passed
```